### PR TITLE
release stack logging, cleanup thread

### DIFF
--- a/FastMM4.pas
+++ b/FastMM4.pas
@@ -6199,7 +6199,6 @@ var
   LStackTrace: TStackTrace;
 {$endif}
 {$ifdef UseReleaseStack}
-  LReleaseCount: integer;
   LPReleaseStack: ^TLFStack;
 {$endif}
 begin
@@ -6262,9 +6261,6 @@ begin
       LPSmallBlockType.BlockCollector.Add(@LStackTrace[0], StackTraceDepth);
     end;
 {$endif}
-{$ifdef UseReleaseStack}
-  LReleaseCount := 0;
-{$endif}
     repeat
       {Get the old first free block}
       LOldFirstFreeBlock := LPSmallBlockPool.FirstFreeBlock;
@@ -6312,13 +6308,10 @@ begin
 {$endif}
 {$ifdef UseReleaseStack}
         LPReleaseStack := @LPSmallBlockType.ReleaseStack[GetStackSlot];
-        if (LReleaseCount < (ReleaseStackSize div 2)) and
-           (not LPReleaseStack^.IsEmpty) and
-           LPReleaseStack^.Pop(APointer) then
+        if (not LPReleaseStack^.IsEmpty) and LPReleaseStack^.Pop(APointer) then
         begin
           LBlockHeader := PNativeUInt(PByte(APointer) - BlockHeaderSize)^;
           LPSmallBlockPool := PSmallBlockPoolHeader(LBlockHeader);
-          Inc(LReleaseCount);
         end
         else
         begin

--- a/FastMM4.pas
+++ b/FastMM4.pas
@@ -3286,18 +3286,16 @@ var
 {$endif}
 
 {$ifdef UseReleaseStack }
-function GetStackSlot: DWORD; {$ifdef CONDITIONALEXPRESSIONS}{$if CompilerVersion >= 17}inline;{$ifend}{$endif}
+function GetStackSlot: DWORD;
 begin
-  Result := (GetCurrentThreadID SHR 4) AND (NumStacksPerBlock-1);
-// A bit slower but probably gives better hash:
-//  Result := GetCurrentThreadID;
-//  Result := (Result XOR 61) XOR (Result SHR 16);
-//  Result := Result + (Result SHL 3);
-//  Result := Result XOR (Result SHR 4);
-//  Result := Result * $27d4eb2d;
-//  Result := Result XOR (Result SHR 15);
-//  Result := Result AND (NumStacksPerBlock-1);
 // http://burtleburtle.net/bob/hash/integer.html
+  Result := GetCurrentThreadID;
+  Result := (Result XOR 61) XOR (Result SHR 16);
+  Result := Result + (Result SHL 3);
+  Result := Result XOR (Result SHR 4);
+  Result := Result * $27d4eb2d;
+  Result := Result XOR (Result SHR 15);
+  Result := Result AND (NumStacksPerBlock-1);
 end;
 {$endif}
 
@@ -12112,10 +12110,8 @@ end;
 
 procedure LogReleaseStackUsage;
 var
-  LBlockSize: NativeUInt;
   LCount: integer;
   LInd: Integer;
-  LMemory: Pointer;
   LMessage: array[0..32767] of AnsiChar;
   LMsgPtr: PAnsiChar;
   LSize: NativeUInt;

--- a/FastMM4Messages.pas
+++ b/FastMM4Messages.pas
@@ -138,6 +138,20 @@ const
   LockingReportHeader = 'Top locking contention sites';
 {$endif}
 
+{$ifdef UseReleaseStack}
+{$ifdef DebugReleaseStack}
+  ReleaseStackUsageHeader = 'Release stack usage statistics';
+  ReleaseStackUsageSmallBlocksMsg1 = 'Small blocks [';
+  ReleaseStackUsageSmallBlocksMsg2 = ']: ';
+  ReleaseStackUsageTotalSmallBlocksMsg = 'Total small blocks: ';
+  ReleaseStackUsageMediumBlocksMsg = 'Medium blocks: ';
+  ReleaseStackUsageLargeBlocksMsg = 'Large blocks: ';
+  ReleaseStackUsageTotalMemoryMsg = 'Total memory: ';
+  ReleaseStackUsageBuffers1Msg = ' in ';
+  ReleaseStackUsageBuffers2Msg = ' buffers [';
+{$endif}
+{$endif}
+
 implementation
 
 end.


### PR DESCRIPTION
1) Added LogReleaseStackUsage function which logs state of release stacks. Has to be enabled with /dDebugReleaseStack.

2) Added low priority background thread which walks through medium and large block release stacks and frees memory. This prevents large quantities of memory to stay "stuck" after a thread is terminated.