### PR TITLE
two fixes for lock contention logger

### DIFF
--- a/FastMM4.pas
+++ b/FastMM4.pas
@@ -5136,7 +5136,7 @@ begin
   if Assigned(ACollector) then 
   begin
     GetStackTrace(@LStackTrace, StackTraceDepth, 1);
-    MediumBlockCollector.Add(@LStackTrace[0], StackTraceDepth);
+    ACollector.Add(@LStackTrace[0], StackTraceDepth);
   end;
 {$endif}
 {$endif}

--- a/FastMM4.pas
+++ b/FastMM4.pas
@@ -5038,6 +5038,15 @@ begin
 {$endif}
           {Done}
           MediumBlocksLocked := False;
+{$ifdef LogLockContention}
+{$ifndef FullDebugMode}
+          if Assigned(ACollector) then
+          begin
+            GetStackTrace(@LStackTrace, StackTraceDepth, 1);
+            ACollector.Add(@LStackTrace[0], StackTraceDepth);
+          end;
+{$endif}
+{$endif}
           Exit;
 {$ifndef FullDebugMode}
         end;


### PR DESCRIPTION
1) MediumBlockCollector was used for all loggin in FastGetMem regardless of which allocator was used to produce the code.

2) There was a code path through FastGetMem where lock contention wasn't logged at all