### PR TITLE
Allow to load debug dll only from host module directory.

### DIFF
--- a/FastMM4Options.inc
+++ b/FastMM4Options.inc
@@ -166,6 +166,9 @@ Set the default options for FastMM here.
      install itself. No effect unless FullDebugMode and LoadDebugDLLDynamically
      are also defined.}
 
+    {.$define RestrictDebugDLLLoadPath}
+    {Allow to load debug dll only from host module directory.}
+
   {FastMM usually allocates large blocks from the topmost available address and
    medium and small blocks from the lowest available address (This reduces
    fragmentation somewhat). With this option set all blocks are always


### PR DESCRIPTION
Restrict FastMM_FullDebugMode.dll dynamic load path to module directory. This option will fix undesired program behavior then debug dll may be located at system search path.