### PR TITLE
makes UseTrackerDemo uses FastMM4.pas in repository, then fixes #67

### DIFF
--- a/Demos/Usage Tracker/UsageTrackerDemo.dproj
+++ b/Demos/Usage Tracker/UsageTrackerDemo.dproj
@@ -13,10 +13,12 @@
     <DCC_LocalDebugSymbols>False</DCC_LocalDebugSymbols>
     <DCC_SymbolReferenceInfo>0</DCC_SymbolReferenceInfo>
     <DCC_Define>RELEASE</DCC_Define>
+    <DCC_UnitSearchPath>..\..</DCC_UnitSearchPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <Version>7.0</Version>
     <DCC_Define>DEBUG</DCC_Define>
+    <DCC_UnitSearchPath>..\..</DCC_UnitSearchPath>
   </PropertyGroup>
   <ProjectExtensions>
     <Borland.Personality>Delphi.Personality</Borland.Personality>

--- a/FastMM4.pas
+++ b/FastMM4.pas
@@ -1462,11 +1462,11 @@ const
   {The pattern used to fill unused memory}
   DebugFillByte = $80;
 {$ifdef 32Bit}
-  DebugFillPattern = $01010101 * Cardinal(DebugFillByte);
+  DebugFillPattern = $01010101 * Cardinal(DebugFillByte); // Default value $80808080
   {The address that is reserved so that accesses to the address of the fill
    pattern will result in an A/V. (Not used under 64-bit, since the upper half
    of the address space is always reserved by the OS.)}
-  DebugReservedAddress = $01010000 * Cardinal(DebugFillByte);
+  DebugReservedAddress = $01010000 * Cardinal(DebugFillByte); // Default value $80800000
 {$else}
   DebugFillPattern = $8080808080808080;
 {$endif}
@@ -12627,7 +12627,7 @@ begin
   begin
 {$ifdef FullDebugMode}
   {$ifdef 32Bit}
-    {Try to reserve the 64K block covering address $80808080}
+    {Try to reserve the 64K block covering address $80808080 so pointers with DebugFillPattern will A/V}
     ReservedBlock := VirtualAlloc(Pointer(DebugReservedAddress), 65536, MEM_RESERVE, PAGE_NOACCESS);
     {Allocate the address space slack.}
     AddressSpaceSlackPtr := VirtualAlloc(nil, FullDebugModeAddressSpaceSlack, MEM_RESERVE or MEM_TOP_DOWN, PAGE_NOACCESS);


### PR DESCRIPTION
fixes #67

- UseTrackerDemo unit search path fix DEBUG + RELEASE mode add DCC_UnitSearchPath..\.. so the FastMM4 unit and include file can be found.
- Document default values of DebugFillPattern and DebugReservedAddress near their definition.
- Point back use of DebugReservedAddress to DebugFillPattern.

This makes it way easier to find back the cause of $8080#### in exceptions like access violations to the FastMM4 code enforcing them.
