### PR TITLE
Implements EnableMemoryLeakReportingUsesQualifiedClassName

### DIFF
--- a/FastMM4.pas
+++ b/FastMM4.pas
@@ -3601,7 +3601,7 @@ type
 function AppendClassNameToBuffer(AClass: TClass; ADestination: PAnsiChar): PAnsiChar;
 var
 {$ifdef EnableMemoryLeakReportingUsesQualifiedClassName}
-  FirstUnitNameChar: AnsiChar;
+  FirstUnitNameChar: PAnsiChar;
   LClassInfo: Pointer;
   UnitName: PShortString;
 {$endif EnableMemoryLeakReportingUsesQualifiedClassName}
@@ -3617,9 +3617,9 @@ begin
     if LClassInfo <> nil then // prepend the UnitName
     begin
       UnitName := @PClassData(PByte(LClassInfo) + 2 + PByte(PByte(LClassInfo) + 1)^).UnitName;
-      FirstUnitNameChar := UnitName^[1];
-      if FirstUnitNameChar <> '@' then
-        Result := AppendStringToBuffer(@FirstUnitNameChar, Result, Length(UnitName^))
+      FirstUnitNameChar := @UnitName^[1];
+      if FirstUnitNameChar^ <> '@' then
+        Result := AppendStringToBuffer(FirstUnitNameChar, Result, Length(UnitName^))
       else // Pos does no memory allocations, so it is safe to use
       begin // Skip the '@', then copy until the ':' - never seen this happen in Delphi, but might be a C++ thing
         Result := AppendStringToBuffer(@UnitName^[2], Result, Pos(ShortString(':'), UnitName^) - 2)

--- a/FastMM4.pas
+++ b/FastMM4.pas
@@ -3585,18 +3585,53 @@ begin
   Result := Pointer(PByte(ADestination) + ACount);
 end;
 
+{$ifdef EnableMemoryLeakReportingUsesQualifiedClassName}
+type
+  PClassData = ^TClassData;
+  TClassData = record
+    ClassType: TClass;
+    ParentInfo: Pointer;
+    PropCount: SmallInt;
+    UnitName: ShortString;
+  end;
+{$endif EnableMemoryLeakReportingUsesQualifiedClassName}
+
 {Appends the name of the class to the destination buffer and returns the new
  destination position}
 function AppendClassNameToBuffer(AClass: TClass; ADestination: PAnsiChar): PAnsiChar;
 var
+{$ifdef EnableMemoryLeakReportingUsesQualifiedClassName}
+  FirstUnitNameChar: AnsiChar;
+  LClassInfo: Pointer;
+  UnitName: PShortString;
+{$endif EnableMemoryLeakReportingUsesQualifiedClassName}
   LPClassName: PShortString;
 begin
   {Get a pointer to the class name}
   if AClass <> nil then
   begin
+    Result := ADestination;
+{$ifdef EnableMemoryLeakReportingUsesQualifiedClassName}
+    // based on TObject.UnitScope
+    LClassInfo := AClass.ClassInfo;
+    if LClassInfo <> nil then // prepend the UnitName
+    begin
+      UnitName := @PClassData(PByte(LClassInfo) + 2 + PByte(PByte(LClassInfo) + 1)^).UnitName;
+      FirstUnitNameChar := UnitName^[1];
+      if FirstUnitNameChar <> '@' then
+        Result := AppendStringToBuffer(@FirstUnitNameChar, Result, Length(UnitName^))
+      else // Pos does no memory allocations, so it is safe to use
+      begin // Skip the '@', then copy until the ':' - never seen this happen in Delphi, but might be a C++ thing
+        Result := AppendStringToBuffer(@UnitName^[2], Result, Pos(ShortString(':'), UnitName^) - 2)
+        ;
+      end;
+      // dot between unit name and class name:
+      Result := AppendStringToBuffer('.', Result, Length('.'));
+    end;
+{$endif EnableMemoryLeakReportingUsesQualifiedClassName}
     LPClassName := PShortString(PPointer(PByte(AClass) + vmtClassName)^);
     {Append the class name}
-    Result := AppendStringToBuffer(@LPClassName^[1], ADestination, Length(LPClassName^));
+    Result := AppendStringToBuffer(@LPClassName^[1], Result, Length(LPClassName^));
   end
   else
   begin

--- a/FastMM4Options.inc
+++ b/FastMM4Options.inc
@@ -237,6 +237,13 @@ Set the default options for FastMM here.
    message.}
   {.$define HideMemoryLeakHintMessage}
 
+  {Set this option to use QualifiedClassName equivalent instead of ClassName
+   equivalent during memory leak reporting.
+   This is useful for duplicate class names (like EConversionError, which is in
+   units Data.DBXJSONReflect, REST.JsonReflect and System.ConvUtils,
+   or TClipboard being in Vcl.Clibprd and WinAPI.ApplicationModel.DataTransfer }
+  {$define EnableMemoryLeakReportingUsesQualifiedClassName}
+
 {--------------------------Instruction Set Options----------------------------}
 
 {Set this option to enable the use of MMX instructions. Disabling this option


### PR DESCRIPTION
fixes #70 

- Implements `EnableMemoryLeakReportingUsesQualifiedClassName` in function `AppendClassNameToBuffer`
- Documents `EnableMemoryLeakReportingUsesQualifiedClassName` in `FastMM4Options.inc`