### PR TITLE
don't allocate large block with MEM_TOP_DOWN by default

### DIFF
--- a/FastMM4.pas
+++ b/FastMM4.pas
@@ -4425,7 +4425,7 @@ begin
   LLargeUsedBlockSize := (ASize + LargeBlockHeaderSize + LargeBlockGranularity - 1 + BlockHeaderSize)
     and -LargeBlockGranularity;
   {Get the Large block}
-  Result := VirtualAlloc(nil, LLargeUsedBlockSize, MEM_COMMIT or MEM_TOP_DOWN,
+  Result := VirtualAlloc(nil, LLargeUsedBlockSize, MEM_COMMIT {$ifdef AllocateLargeBlocksTopDown} or MEM_TOP_DOWN{$endif},
     PAGE_READWRITE);
   {Set the Large block fields}
   if Result <> nil then


### PR DESCRIPTION
As it turns out (analysis here: https://www.thedelphigeek.com/2019/04/fastmm4-large-memory.html), allocating memory blocks with MEM_TOP_DOWN can bring in 5-15% penalty.

I'm proposing adding conditional symbol AllocateLargeBlocksTopDown. If it is defined, large blocks are allocated with MEM_TOP_DOWN, otherwise they are not.

By default, AllocateLargeBlocksTopDown should not be defined.