### PR TITLE
Clamp lock-free stack calibration loop counts to [1, 10000]

### DIFF
--- a/FastMM4LockFreeStack.pas
+++ b/FastMM4LockFreeStack.pas
@@ -248,8 +248,16 @@ begin
       end;
       //Calculate first 4 minimum average for RemoveLink rutine
       obsTaskPopLoops := GetMinAndClear(0, 4) div 4;
+      if obsTaskPopLoops < 1 then
+        obsTaskPopLoops := 1
+      else if obsTaskPopLoops > 10000 then
+        obsTaskPopLoops := 10000;
       //Calculate first 4 minimum average for InsertLink rutine
       obsTaskPushLoops := GetMinAndClear(1, 4) div 4;
+      if obsTaskPushLoops < 1 then
+        obsTaskPushLoops := 1
+      else if obsTaskPushLoops > 10000 then
+        obsTaskPushLoops := 10000;
 
       //This gives better performance (determined experimentally)
       obsTaskPopLoops := obsTaskPopLoops * 2;


### PR DESCRIPTION
## Summary

`TLFStack.InitializeObserver` runs a short timing micro-benchmark to
calibrate `obsTaskPopLoops` / `obsTaskPushLoops`, then uses those as
spin counts in `PopLink` / `PushLink`. On hardware where the sampled
timings round to zero (CPUs fast enough to hit the `GetCPUTimeStamp`
granularity) or come back anomalously large (thread migration, kernel
jitter), the computed value `GetMinAndClear(routine, 4) div 4` can be
0 or huge. Zero is the more dangerous case — the subsequent `* 2`
stays zero, collapsing the spin loops to zero iterations.

Clamp both counters to `[1, 10000]` right after `GetMinAndClear`. `1`
keeps at least one spin iteration; `10000` is well above what any
reasonable CPU would need.

## Test plan

- [x] Change is localized (8 added lines in `FastMM4LockFreeStack.pas`).
- [x] Behavior preserved for values already in range.
- [ ] Maintainer review / CI.